### PR TITLE
Update strings.po

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -11135,7 +11135,7 @@ msgstr "Съедобные, перегнившие помои, могут выз
 #. STRINGS.ITEMS.FOOD.MUSHBAR.NAME
 msgctxt "STRINGS.ITEMS.FOOD.MUSHBAR.NAME"
 msgid "Mush Bar"
-msgstr "Мшистый батончик"
+msgstr "Липкий брикет"
 
 #. STRINGS.ITEMS.FOOD.MUSHBAR.RECIPEDESC
 msgctxt "STRINGS.ITEMS.FOOD.MUSHBAR.RECIPEDESC"


### PR DESCRIPTION
Предлагаю "Мшистый батончик" переименовать в "Липкий брикет". Данный тип еды готовится из грязи под воздействием микробов, и результат явно не мох, а субстанция "Mush" - продукт жизнедеятельности микробов. "Mush" в переводе мог бы означать "каша", "пюре", но прямой перевод в данном случае не подходит, поэтому можно взять свойство каши или пюре - Липкость.

Слово "батончик" на мой взгляд тоже не подходит, т.к. размер еды очевидно больше